### PR TITLE
(WIP) gmail api instead of smtp

### DIFF
--- a/messages.py
+++ b/messages.py
@@ -1,4 +1,8 @@
 import random
+from email.message import EmailMessage
+from email.mime.text import MIMEText
+import mimetypes
+import base64
 
 """
     Template credit: nomoreracistcops.github.io
@@ -128,3 +132,31 @@ def gen_closing(name):
             "Best",
     ]
     return "\n%s,\n%s" % (random.choice(c), name)
+
+
+def gen_messages(recv, subject, message, src_name, src_email, smtp=False):
+    while recv:
+        recipient = recv.pop()
+        dst_name = recipient[0]
+        location = recipient[1]
+        dst_email = recipient[2]
+
+        subject = subject if subject else gen_subject()
+        body = attach_greeting(dst_name, message) if message else gen_body(src_name, dst_name, location)
+
+        if smtp:
+            msg = EmailMessage()
+            msg['Subject'] = subject
+            msg['From'] = src_email
+            msg['To'] = dst_email
+
+
+            msg.set_content(body)
+        else:
+              message = MIMEText(body)
+              message['to'] = dst_email
+              message['from'] = src_email
+              message['subject'] = subject
+              raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+              msg = {'raw': raw}
+        yield msg


### PR DESCRIPTION
This branch has some boilerplate that lets you run the main script with the gmail API.... if you have a client_secret.json locally in your repo that comes from a Google Project with the GMail API's "send" endpoint enabled. I set my own up to test this out; I could push it but then anyone could pretend to be our project when making requests to Google Mail I think... Also, even if everyone were to somehow get their own client secret, they need to get past an "unverified app" screen to get OAuth to work. And, even if I was to push my client_secret.json, we would still only be able to let 100 email addresses use the service before needing verification from Google (see https://support.google.com/cloud/answer/7454865 )

I mentioned a few more details about the "where to put the client secret" problem in Issue #5. Of course, we shouldn't merge this until we fix the above problem. If this project was a webpage (see issue #9 ), the confusion of where to put the client secret would be resolved, but being verified by Google would still be required to go past 100 users (and get rid of the scary "unverified app" screen during OAuth)