### PR TITLE
New function to convert recipients list to javascript dictionary for frontend

### DIFF
--- a/recipients.py
+++ b/recipients.py
@@ -691,3 +691,30 @@ def get_cities(state):
     lst = ["Select All"]
     lst.extend(mailing_list[state].keys())
     return lst
+
+"""
+prints a javascript dictionary of the form
+...
+{
+    label: "San Antonio",
+    name: "Councilmember Roberto C. Trevino",
+    email: "district1@sanantonio.gov"
+},
+{
+    label: "San Antonio",
+    name: "Councilmember Jada Andrews-Sullivan",
+    email: "district2@sanantonio.gov"
+}
+...
+"""
+def convert_to_js_dict():
+    for state in mailing_list:
+        for county in mailing_list[state]:
+            people = mailing_list[state][county]
+            for p in people:
+                print('{\n\tlabel: "%s",\n\tname: "%s",\n\temail: "%s",\n},' % (p[1], p[0], p[2]))
+
+def convert_to_js_dict_and_save_to(filename):
+    import sys
+    sys.stdout = open(filename, 'w')
+    convert_to_js_dict()


### PR DESCRIPTION
just need to call convert_to_js_dict(), or call convert_to_js_dict_and_save_to(filename)

will make it easier for frontend to update recipient lists